### PR TITLE
Add simple logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ _resampled
 /metatitle/
 /node_modules/
 /securitytemplates/
+/silverstripe-loggerbridge/
 /vendor/
 /yepnopesilverstripe/

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "kinglozzer/htmleditornoalignment": "1.0.*",
         "feejin/silverstripe-securitytemplates": "1.0.*",
         "stnvh/silverstripe-infoboxes": "1.*",
-        "jonom/silverstripe-betternavigator": "dev-master"
+        "jonom/silverstripe-betternavigator": "dev-master",
+        "camspiers/silverstripe-loggerbridge": "dev-master"
     },
     "autoload": {
         "psr-0": {

--- a/mysite/_config/logging.yml
+++ b/mysite/_config/logging.yml
@@ -1,0 +1,13 @@
+Injector:
+    Monolog:
+        class: Monolog\Logger
+        constructor:
+            0: 'default'
+            1:
+                - '%$ErrorLogHandler'
+    ErrorLogHandler:
+        class: Monolog\Handler\ErrorLogHandler
+    LoggerBridge:
+        class: Camspiers\LoggerBridge\LoggerBridge
+        constructor:
+            0: '%$Monolog'

--- a/util/Installer/Install.php
+++ b/util/Installer/Install.php
@@ -84,10 +84,10 @@ class Install {
 		if ( ! stristr(__DIR__, 'Devsites')) exit;
 
 		$base = __DIR__ . '/../../';
-		$yamlPath = $base . 'mysite/_config/config.yml';
-
 		include($base . 'framework/thirdparty/spyc/spyc.php');
-		$contents = file_get_contents($yamlPath);
+
+		$configPath = $base . 'mysite/_config/config.yml';
+		$contents = file_get_contents($configPath);
 		$config = \Spyc::YAMLLoad($contents);
 
 		// Rename theme directory
@@ -118,8 +118,20 @@ class Install {
 			$config['Database']['name'] = $conf['sql-name'];
 		}
 
+		// Write our updated config file
 		$yaml = \Spyc::YAMLDump($config);
-		file_put_contents($yamlPath, $yaml);
+		file_put_contents($configPath, $yaml);
+
+		// Rename app name in logging configuration
+		$loggingPath = $base . 'mysite/_config/logging.yml';
+		$contents = file_get_contents($loggingPath);
+		$config = \Spyc::YAMLLoad($contents);
+		
+		$desc = $conf['description'] ?: 'App';
+		$config['Injector']['Monolog']['constructor'][0] = "'$desc'";
+
+		$yaml = \Spyc::YAMLDump($config);
+		file_put_contents($loggingPath, $yaml);
 	}
 
 	/**


### PR DESCRIPTION
This will write log files one level above the document root to `error.log`. It also replaces the default error handler with [Whoops](http://filp.github.io/whoops/demo/) so it’s prettier.

We can use any handler that’s available with Monolog 1.7 (they’re listed on [this page](https://github.com/Seldaek/monolog/tree/1.7.0)), any suggestions for something more useful we could do with live sites? I’ve a feeling error logs will be neglected!
