### PR TITLE
Restructure SCSS files & folders

### DIFF
--- a/themes/default/scss/components/_breadcrumbs.scss
+++ b/themes/default/scss/components/_breadcrumbs.scss
@@ -1,0 +1,20 @@
+/* Component: breadcrumbs
+---------------------------------------------------------------------------------- */
+
+.breadcrumbs {
+	font-size: 140%;
+
+	a {
+		color: $brand-pri;
+
+		&:link,
+		&:visited {
+			text-decoration: none;
+		}
+
+		&:active,
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}

--- a/themes/default/scss/components/_footer.scss
+++ b/themes/default/scss/components/_footer.scss
@@ -1,7 +1,0 @@
-footer {
-	background: $black;
-
-	@include respond(960px) {
-		background: $white;
-	}
-}

--- a/themes/default/scss/components/_header.scss
+++ b/themes/default/scss/components/_header.scss
@@ -1,8 +1,0 @@
-header {
-	color: $black;
-	background: $white;
-
-	@include retina {
-		// Retina rules here
-	}
-}

--- a/themes/default/scss/editor.scss
+++ b/themes/default/scss/editor.scss
@@ -1,10 +1,10 @@
 /* For CMS HtmlEditorField
 ---------------------------------------------------------------------------------- */
 
-@import 'includes/_reset';
-@import 'includes/_normalize';
-@import 'includes/_variables';
-@import 'includes/_typography';
+@import 'includes/reset';
+@import 'includes/normalize';
+@import 'includes/variables';
+@import 'includes/typography';
 
 body.mceContentBody {
 	font-size: 13px;

--- a/themes/default/scss/layout/_footer.scss
+++ b/themes/default/scss/layout/_footer.scss
@@ -1,0 +1,10 @@
+/* Layout: footer
+---------------------------------------------------------------------------------- */
+
+footer {
+	background: $black;
+
+	@include respond(960px) {
+		background: $white;
+	}
+}

--- a/themes/default/scss/layout/_header.scss
+++ b/themes/default/scss/layout/_header.scss
@@ -1,0 +1,11 @@
+/* Layout: header
+---------------------------------------------------------------------------------- */
+
+header {
+	color: $black;
+	background: $white;
+
+	@include retina {
+		// Retina rules here
+	}
+}

--- a/themes/default/scss/style.scss
+++ b/themes/default/scss/style.scss
@@ -1,9 +1,9 @@
-@import 'includes/_reset';
-@import 'includes/_normalize';
-@import 'includes/_variables';
-@import 'includes/_typography';
-@import 'includes/_mixins';
-@import 'includes/_utils';
+@import 'includes/reset';
+@import 'includes/normalize';
+@import 'includes/variables';
+@import 'includes/typography';
+@import 'includes/mixins';
+@import 'includes/utils';
 
 /* Layout
 ---------------------------------------------------------------------------------- */
@@ -14,5 +14,9 @@
 
 $_is_ie: false;
 
-@import 'components/_header';
-@import 'components/_footer';
+// Core layout
+@import 'layout/header';
+@import 'layout/footer';
+
+// Reusable components
+@import 'components/breadcrumbs';

--- a/themes/default/scss/style_ie8.scss
+++ b/themes/default/scss/style_ie8.scss
@@ -1,9 +1,9 @@
-@import 'includes/_reset';
-@import 'includes/_normalize';
-@import 'includes/_variables';
-@import 'includes/_typography';
-@import 'includes/_mixins';
-@import 'includes/_utils';
+@import 'includes/reset';
+@import 'includes/normalize';
+@import 'includes/variables';
+@import 'includes/typography';
+@import 'includes/mixins';
+@import 'includes/utils';
 
 /* Layout
 ---------------------------------------------------------------------------------- */
@@ -13,10 +13,12 @@
 	*behavior: url('/polyfill/box-sizing/boxsizing.htc');
 }
 
-/* Import required files without media queries
----------------------------------------------------------------------------------- */
-
+// Disables media queries
 $_is_ie: true;
 
-@import 'components/_header';
-@import 'components/_footer';
+// Core layout
+@import 'layout/header';
+@import 'layout/footer';
+
+// Reusable components
+@import 'components/breadcrumbs';


### PR DESCRIPTION
Have been thinking over this while working. I think “layout” is a better name for larger components of a site, “components” sorta suggests micro/re-usable which header and footer aren’t. For small sites it doesn’t matter so much, but on bigger ones it feels weird having huge header/footer components mixed in with tiny re-usable ones - plus the list of files gets huge.

I also tend to put page-specific styles in their own directory (e.g. `pages/_document-search.scss` - could also be `content/_page-name.scss`), and put off-canvas stuff in `function/_off-canvas`. Not sure about the latter: I put it in its own file so it wasn’t imported into IE8 CSS and it’s more function than form, so I stole the folder name from the default Magento theme.

Old:

```
components:
  - _header.scss
  - _footer.scss
```

New:

```
components:
  - _breadcrumbs.scss
layout:
  - _header.scss
  - _footer.scss
```
