### PR TITLE
Use more appropriate name for font-size mixin

### DIFF
--- a/themes/default/scss/includes/_mixins.scss
+++ b/themes/default/scss/includes/_mixins.scss
@@ -4,11 +4,9 @@
 /* REM sizing
 ---------------------------------------------------------------------------------- */
 @mixin rem-fontsize($size) {
-	font-size: $size * 1px;
-	font-size: ($size * 1rem/10);
+	@include font-size($size);
 }
 
-// alt name
 @mixin font-size($size) {
 	font-size: $size * 1px;
 	font-size: ($size * 1rem/10);


### PR DESCRIPTION
I'm always finding myself doing `rem-font-size` etc. and it makes it easier to have the mixin as just `font-size`.
Kept the old one for backwards compatibility.
