### PR TITLE
Strip styles when pasting into TinyMCE

### DIFF
--- a/mysite/_config.php
+++ b/mysite/_config.php
@@ -37,8 +37,6 @@ HtmlEditorConfig::get('cms')->setButtonsForLine(1, "formatselect,separator,bulli
 HtmlEditorConfig::get('cms')->setButtonsForLine(2, "tablecontrols");
 HtmlEditorConfig::get('cms')->setButtonsForLine(3, '');
 HtmlEditorConfig::get('cms')->setOptions(array(
-	'paste_text_sticky' => 'true',
-	'paste_text_sticky_default' => 'true',
 	'paste_auto_cleanup_on_paste' => 'true',
 	'paste_remove_styles' => 'true',
 	'paste_strip_class_attributes' => 'all',


### PR DESCRIPTION
Removes content formatting when pasting into TinyMCE (essentially paste and match style, only paste and strip existing style).
