### PR TITLE
Remove default admin/password login

### DIFF
--- a/mysite/_config.php
+++ b/mysite/_config.php
@@ -19,9 +19,6 @@ require_once 'conf/ConfigureFromEnv.php';
 // Set the site locale
 i18n::set_locale('en_GB');
 
-// Set default password - remove this after creating a proper user
-Security::setDefaultAdmin('admin', 'password');
-
 // TinyMCE Config
 $config = HtmlEditorConfig::get('cms');
 $config->disablePlugins('emotions', 'fullscreen');


### PR DESCRIPTION
It’s one less thing to forget about. We can just put this in our development `_ss_environment.php` to achieve the same result:

```php
define('SS_DEFAULT_ADMIN_USERNAME', 'admin');
define('SS_DEFAULT_ADMIN_PASSWORD', 'password');
```