### PR TITLE
Don’t append query strings to requirements

### DIFF
--- a/mysite/code/Page.php
+++ b/mysite/code/Page.php
@@ -24,6 +24,7 @@ class Page_Controller extends ContentController {
 
 		$themeDir = 'themes/' . Config::inst()->get('SSViewer', 'theme');
 
+		Requirements::set_suffix_requirements(false);
 		Requirements::combine_files(
 			'application.js',
 			array (


### PR DESCRIPTION
Thoughts? Currently script tags are output with URLs like: `/themes/default/js/app.min.js?m=1443619095`. Pagespeed recommends dropping them (it mentions proxy servers/caching as the reason), do we want to take any notice?