### PR TITLE
(DON’T MERGE) FIX: Non-fatal errors being treated as fatal in test/live environments

### DIFF
--- a/mysite/_config/logging.yml
+++ b/mysite/_config/logging.yml
@@ -1,3 +1,7 @@
+---
+Name: 'logging'
+After: 'silverstripe-loggerbridge'
+---
 Injector:
     Monolog:
         class: Monolog\Logger
@@ -11,3 +15,13 @@ Injector:
         class: Camspiers\LoggerBridge\LoggerBridge
         constructor:
             0: '%$Monolog'
+---
+Name: 'livelogging'
+After: '#logging'
+Except:
+  environment: dev
+---
+Injector:
+  LoggerBridge:
+    properties:
+      ErrorReporter: '%$LoggerBridgeDebugErrorReporter'


### PR DESCRIPTION
Don’t merge yet, I need to test this some more...

This restores standard SilverStripe error reporting for test/live environment types. [`Whoops`](https://github.com/filp/whoops) transforms warnings and other non-fatal errors to `ErrorException`s, so rather than suppressing a warning and carrying on users will be shown a 500 internal server error.