### PR TITLE
wow very update, such changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "silverstripe/cms": "~3.2.0",
         "silverstripe/framework": "~3.2.0",
         "silverstripe/googlesitemaps": "1.2.*",
-        "silverstripe-australia/gridfieldextensions": "~1.3.0",
+        "silverstripe-australia/gridfieldextensions": "~1.1.0",
         "stnvh/silverstripe-infoboxes": "1.*",
         "unclecheese/betterbuttons" : "~1.2.0"
     },

--- a/mysite/_config/config.yml
+++ b/mysite/_config/config.yml
@@ -1,5 +1,15 @@
+---
+Name: 'default'
+---
 Database:
   host: 'default'
   name: 'default'
 SSViewer:
   theme: 'default'
+---
+Name: 'focuspoint-connector'
+Only:
+  moduleexists: silverstripe-responsive-images
+---
+FocusPointImage:
+  flush_on_change: true

--- a/mysite/_config/logging.yml
+++ b/mysite/_config/logging.yml
@@ -1,3 +1,7 @@
+---
+Name: 'logging'
+After: 'silverstripe-loggerbridge'
+---
 Injector:
     Monolog:
         class: Monolog\Logger
@@ -11,3 +15,13 @@ Injector:
         class: Camspiers\LoggerBridge\LoggerBridge
         constructor:
             0: '%$Monolog'
+---
+Name: 'livelogging'
+After: '#logging'
+Except:
+  environment: dev
+---
+Injector:
+  LoggerBridge:
+    properties:
+      ErrorReporter: '%$LoggerBridgeDebugErrorReporter'

--- a/mysite/_config/logging.yml
+++ b/mysite/_config/logging.yml
@@ -3,18 +3,18 @@ Name: 'logging'
 After: 'silverstripe-loggerbridge'
 ---
 Injector:
-    Monolog:
-        class: Monolog\Logger
-        constructor:
-            0: 'default'
-            1:
-                - '%$ErrorLogHandler'
-    ErrorLogHandler:
-        class: Monolog\Handler\ErrorLogHandler
-    LoggerBridge:
-        class: Camspiers\LoggerBridge\LoggerBridge
-        constructor:
-            0: '%$Monolog'
+  Monolog:
+    class: Monolog\Logger
+    constructor:
+      0: 'default'
+      1:
+        - '%$ErrorLogHandler'
+  ErrorLogHandler:
+    class: Monolog\Handler\ErrorLogHandler
+  LoggerBridge:
+    class: Camspiers\LoggerBridge\LoggerBridge
+    constructor:
+      0: '%$Monolog'
 ---
 Name: 'livelogging'
 After: '#logging'

--- a/util/Bigfork/Installer/Install.php
+++ b/util/Bigfork/Installer/Install.php
@@ -244,13 +244,34 @@ class Install
      */
     protected static function updateLoggingConfig($filePath, array $config)
     {
-        $yamlConfig = Spyc::YAMLLoad(file_get_contents($filePath));
+        $contents = file_get_contents($filePath);
+        $blocks = preg_split('/^---$/m', $contents, -1, PREG_SPLIT_NO_EMPTY);
 
-        $desc = $config['description'] ?: 'App';
-        $yamlConfig['Injector']['Monolog']['constructor'][0] = "'{$desc}'";
+        $mainBlock = false;
+        $parsedBlocks = array();
+        for ($i = 0; $i < count($blocks); $i++) {
+            $yamlConfig = Spyc::YAMLLoad($blocks[$i]);
 
-        $yaml = Spyc::YAMLDump($yamlConfig);
-        file_put_contents($filePath, $yaml);
+            // Flag that we've hit the "main" block we want to perform renaming on
+            if (isset($yamlConfig['Name']) && $yamlConfig['Name'] === 'logging') {
+                $mainBlock = true;
+            } elseif ($mainBlock) {
+                // Update YAML config
+                $desc = $config['description'] ?: 'App';
+                $yamlConfig['Injector']['Monolog']['constructor'][0] = "'{$desc}'";
+
+                $mainBlock = false;
+            }
+
+            $parsedBlocks[] = $yamlConfig;
+        }
+
+        // Write our updated config file
+        $config = implode('', array_map(function($block) {
+            return Spyc::YAMLDump($block);
+        }, $parsedBlocks));
+
+        file_put_contents($filePath, $config);
     }
 
     /**

--- a/util/Bigfork/Installer/Install.php
+++ b/util/Bigfork/Installer/Install.php
@@ -202,19 +202,38 @@ class Install
      */
     protected static function updateYamlConfig($filePath, array $config)
     {
-        $yamlConfig = Spyc::YAMLLoad(file_get_contents($filePath));
+        $contents = file_get_contents($filePath);
+        $blocks = preg_split('/^---$/m', $contents, -1, PREG_SPLIT_NO_EMPTY);
 
-        // Update YAML config
-        $yamlConfig['SSViewer']['theme'] = $config['theme'];
-        
-        if (isset($config['sql-host']) || isset($config['sql-name'])) {
-            $yamlConfig['Database']['host'] = $config['sql-host'];
-            $yamlConfig['Database']['name'] = $config['sql-name'];
+        $mainBlock = false;
+        $parsedBlocks = array();
+        for ($i = 0; $i < count($blocks); $i++) {
+            $yamlConfig = Spyc::YAMLLoad($blocks[$i]);
+
+            // Flag that we've hit the "main" block we want to perform renaming on
+            if (isset($yamlConfig['Name']) && $yamlConfig['Name'] === 'default') {
+                $mainBlock = true;
+            } elseif ($mainBlock) {
+                // Update YAML config
+                $yamlConfig['SSViewer']['theme'] = $config['theme'];
+                
+                if (isset($config['sql-host']) || isset($config['sql-name'])) {
+                    $yamlConfig['Database']['host'] = $config['sql-host'];
+                    $yamlConfig['Database']['name'] = $config['sql-name'];
+                }
+
+                $mainBlock = false;
+            }
+
+            $parsedBlocks[] = $yamlConfig;
         }
 
         // Write our updated config file
-        $yaml = Spyc::YAMLDump($yamlConfig);
-        file_put_contents($filePath, $yaml);
+        $config = implode('', array_map(function($block) {
+            return Spyc::YAMLDump($block);
+        }, $parsedBlocks));
+
+        file_put_contents($filePath, $config);
     }
 
     /**


### PR DESCRIPTION
- When using both focuspoint and responsive images modules, changing the focus point didn’t regenerate the images. As of https://github.com/jonom/silverstripe-focuspoint/pull/19, that can be forced, so I’ve added [config to enable that](https://github.com/bigfork/SilverStripe-Shoelace/commit/f38a5cfdf7635e34be8bb0bdddf4005fff43b238#diff-b7a75d1d8defdaade92bc30ed3affa1aR9). It’d be better to check in that header block that _both_ modules are installed, but tis not possible because SilverStripe can’t parse arrays out of `moduleexists`.
- Logging has been updated for live mode so that non-fatal errors (i.e. `E_USER_WARNING`) aren’t treated like fatal ones, and don’t show a server error page when they shouldn’t. Replacement of #54.
- 4 spaces for YAML indentation is not valid, so fixed that.
- I broke our composer install by introducing a conflict between GridFieldExtensions and Menu Manager. Reverting that until my PR for Menu Manager is merged.

Both of the config changes needed some awkward PHP changes because no YAML parsers support multiple blocks (hmph). I used the same technique (`preg_split()`) that SilverStripe does in core, so it shouldn’t break anything that wouldn’t have already been broken.