### PR TITLE
Remove URLSegment field for home page

### DIFF
--- a/mysite/code/Page.php
+++ b/mysite/code/Page.php
@@ -1,6 +1,21 @@
 <?php
 
 class Page extends SiteTree {
+	
+	/**
+	 * @return FieldList 
+	 */
+	public function getCMSFields() {
+		$self =& $this;
+		$this->beforeUpdateCMSFields(function($fields) use ($self) {
+			$homeURL = Config::inst()->get('RootURLController', 'default_homepage_link');
+			if (!Permission::check('ADMIN') && self->URLSegment === $homeURL) {
+				$fields->removeByName('URLSegment');
+			}
+		});
+		
+		return parent::getCMSFields();
+	}
 
 	/**
 	 * @return FieldList $fields

--- a/mysite/code/Page.php
+++ b/mysite/code/Page.php
@@ -9,7 +9,7 @@ class Page extends SiteTree {
 		$self =& $this;
 		$this->beforeUpdateCMSFields(function($fields) use ($self) {
 			$homeURL = Config::inst()->get('RootURLController', 'default_homepage_link');
-			if (!Permission::check('ADMIN') && self->URLSegment === $homeURL) {
+			if (!Permission::check('ADMIN') && $self->URLSegment === $homeURL) {
 				$fields->removeByName('URLSegment');
 			}
 		});


### PR DESCRIPTION
Thoughts? Thankfully fairly rare, but it has happened where people break their site by changing this.

I added `$self` for 5.3 compatibility just in case we end up on ancient hosting, but I’m now thinking I should probably just remove it - it’s a very rare occurrence.

Perhaps we should omit the admin check too? When does anyone ever change the home page URL?