### PR TITLE
Disable "New Record" button in top-right

### DIFF
--- a/mysite/_config/config.yml
+++ b/mysite/_config/config.yml
@@ -13,3 +13,11 @@ Only:
 ---
 FocusPointImage:
   flush_on_change: true
+---
+Name: betterbuttonsconfig
+---
+BetterButtonsUtils:
+  create:
+    BetterButton_New: false
+  edit:
+    BetterButton_New: false


### PR DESCRIPTION
It’s possible to replace it with a “Save & Add New” button, but the issue with that is that you don’t get any feedback to say “Item saved successfully” - it just replaces the form with an empty one.