### PR TITLE
scss-lint updates

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,16 +1,29 @@
-# Default application configuration that all configurations inherit from.
 linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+
+  BemDepth:
+    enabled: true
+    max_elements: 1
+
   BorderZero:
     enabled: true
+    convention: zero # or `none`
 
-  CapitalizationInSelector:
+  ChainedClasses:
     enabled: false
 
   ColorKeyword:
     enabled: true
 
+  ColorVariable:
+    enabled: true
+
   Comment:
     enabled: false
+    style: silent
 
   DebugStatement:
     enabled: true
@@ -18,8 +31,15 @@ linters:
   DeclarationOrder:
     enabled: true
 
+  DisableLinterReason:
+    enabled: false
+
   DuplicateProperty:
     enabled: false
+
+  ElsePlacement:
+    enabled: false
+    style: same_line # or 'new_line'
 
   EmptyLineBetweenBlocks:
     enabled: true
@@ -28,27 +48,44 @@ linters:
   EmptyRule:
     enabled: false
 
+  ExtendDirective:
+    enabled: false
+
   FinalNewline:
     enabled: true
     present: true
 
-  HexFormat:
+  HexLength:
+    enabled: false
+    style: sort # or 'long'
+
+  HexNotation:
+    enabled: true
+    style: lowercase # or 'uppercase'
+
+  HexValidation:
     enabled: true
 
   IdSelector:
     enabled: false
 
-  IdWithExtraneousSelector:
+  ImportantRule:
     enabled: true
 
-  ImportantRule:
-    enabled: false
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
 
   Indentation:
-    enabled: false
+    enabled: true
+    allow_non_nested_indentation: false
+    character: tab # or 'tab'
+    width: 1
 
   LeadingZero:
     enabled: false
+    style: exclude_zero # or 'include_zero'
 
   MergeableSelector:
     enabled: true
@@ -56,13 +93,21 @@ linters:
 
   NameFormat:
     enabled: false
-    convention: hyphenated_lowercase # or 'BEM', or a regex pattern
+    allow_leading_underscore: true
+    convention: ^_?([^_-]+(__[^_-]+)?)(--[^_-]+)?$ # or 'BEM', or a regex pattern
 
   NestingDepth:
     enabled: false
+    max_depth: 3
+    ignore_parent_selectors: false
 
   PlaceholderInExtend:
     enabled: true
+
+  PropertyCount:
+    enabled: false
+    include_nested: false
+    max_properties: 10
 
   PropertySortOrder:
     enabled: true
@@ -73,6 +118,9 @@ linters:
     enabled: true
     extra_properties: ['*behavior']
 
+  PseudoElement:
+    enabled: false
+
   QualifyingElement:
     enabled: false
 
@@ -81,18 +129,25 @@ linters:
     max_depth: 3
 
   SelectorFormat:
-    enabled: false
+    enabled: true
+    convention: ^([^_-]+(__[^_-]+)?)(--[^_-]+)?$
 
   Shorthand:
     enabled: true
 
   SingleLinePerProperty:
-    enabled: false
+    enabled: true
 
   SingleLinePerSelector:
     enabled: true
 
   SpaceAfterComma:
+    enabled: true
+
+  SpaceAroundOperator:
+    enabled: true
+
+  SpaceAfterVariableName:
     enabled: true
 
   SpaceAfterPropertyColon:
@@ -113,7 +168,16 @@ linters:
     enabled: true
     style: single_quotes # or double_quotes
 
-  TrailingSemicolonAfterPropertyValue:
+  TrailingSemicolon:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  TrailingZero:
+    enabled: false
+
+  TransitionAll:
     enabled: true
 
   UnnecessaryMantissa:
@@ -127,7 +191,7 @@ linters:
 
   VendorPrefix:
     enabled: false
-  
+
   VendorPrefixes:
     enabled: false
 

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -129,7 +129,7 @@ linters:
     max_depth: 3
 
   SelectorFormat:
-    enabled: true
+    enabled: false
     convention: ^([^_-]+(__[^_-]+)?)(--[^_-]+)?$
 
   Shorthand:

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -57,13 +57,15 @@ var gulp = require('gulp'),
 
 // lint css
 gulp.task('scss-lint', function() {
-	scsslint = require('gulp-scsslint');
+	scsslint = require('gulp-scss-lint');
 
 	var conf = opt.scsslint;
 
 	return gulp.src(conf.src)
-		.pipe(scsslint('.scss-lint.yml'))
-		.pipe(scsslint.reporter(handle.lint.error))
+		.pipe(scsslint({
+			config: '.scss-lint.yml'
+		}))
+		.pipe(scsslint.failReporter())
 });
 
 // compile scss into css

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "gulp": "3.x",
     "gulp-bigfork-handler": "bigfork/gulp-handler",
     "gulp-plumber": "1.0.x",
-    "gulp-scsslint": "0.x",
+    "gulp-scss-lint": "0.x",
     "gulp-sass": "2.x",
     "gulp-autoprefixer": "3.x",
     "gulp-combine-mq": "frontendfriends/gulp-combine-mq#ae31a50",

--- a/themes/default/scss/includes/_mixins.scss
+++ b/themes/default/scss/includes/_mixins.scss
@@ -5,7 +5,7 @@
 ---------------------------------------------------------------------------------- */
 @mixin font-size($size) {
 	font-size: $size * 1px;
-	font-size: ($size * 1rem/10);
+	font-size: ($size * 1rem / 10);
 }
 
 /* Column generator - generate % width column based on pixel values


### PR DESCRIPTION
This updates the gulp plugin to use a more well maintained, and quicker alternative - in-turn, needing the updated version of the gem:

If the output of `which gem` is `/usr/local/bin/gem`:
`gem update --system && gem uninstall scss-lint && gem install scss_lint`

else, `sudo` the lot!

------

I [wrote some regex](https://github.com/bigfork/SilverStripe-Shoelace/blob/dev/lint-updates/.scss-lint.yml#L133) for our BEM-ish selector format, rule is no more than one "element" or "modifier" e.g `.nav__item--active` & `.nav--green` is ok, but `.nav__item__cell--active` isn't. Also hyphens aren't allowed in the block or element bits, so `.nav-head__item` would also be invalid.
Thoughts? Anything that I've missed?