### PR TITLE
Add browserify

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -25,6 +25,10 @@ var gulp = require('gulp'),
 	uglify = null,
 	babel = null,
 
+	browserify = null,
+	source = null,
+	buffer = null,
+
 	/* img */
 	tinypng = null,
 
@@ -101,17 +105,21 @@ gulp.task('js', function() {
 	jshint  = require('gulp-jshint');
 	uglify = require('gulp-uglify');
 	babel = require('gulp-babel');
+	browserify = require('browserify');
+	source = require('vinyl-source-stream');
+	buffer = require('vinyl-buffer');
 
 	var conf = opt.js;
 
-	return gulp.src(conf.src)
+	return browserify('./themes/' + pkg.name + '/js/src/app.js').bundle()
 		.pipe(plumber({errorHandler: handle.generic.error}))
+		.pipe(source('app.min.js'))
+		.pipe(buffer())
 		.pipe(jshint({
 			esnext: true
 		}))
 		.pipe(babel())
 		.pipe(uglify())
-		.pipe(concat('app.min.js'))
 		.pipe(handle.generic.log('compiled'))
 		.pipe(handle.notify.show('JS compiled - <%= file.relative %>'))
 		.pipe(gulp.dest(conf.dest));

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "gulp-cssnano": "2.x",
     "gulp-babel": "5.x",
     "gulp-watch": "4.x",
-    "browser-sync": "2.x"
+    "browser-sync": "2.x",
+    "browserify": "13.x",
+    "vinyl-buffer": "1.x",
+    "vinyl-source-stream": "1.x"
   },
   "description": "Default",
   "main": "Gulpfile.js",

--- a/themes/default/js/app.min.js
+++ b/themes/default/js/app.min.js
@@ -1,6 +1,1 @@
-/*!
- * Default
- * @author Bigfork
- * (c) Bigfork 2014.
- */
-!function(){"use strict"}();
+"use strict";!function t(a,n,e){function r(o,c){if(!n[o]){if(!a[o]){var f="function"==typeof require&&require;if(!c&&f)return f(o,!0);if(i)return i(o,!0);var u=new Error("Cannot find module '"+o+"'");throw u.code="MODULE_NOT_FOUND",u}var d=n[o]={exports:{}};a[o][0].call(d.exports,function(t){var n=a[o][1][t];return r(n?n:t)},d,d.exports,t,a,n,e)}return n[o].exports}for(var i="function"==typeof require&&require,o=0;o<e.length;o++)r(e[o]);return r}({1:[function(t,a,n){t("./ga.bigfork")},{"./ga.bigfork":2}],2:[function(t,a,n){!function(t){var a=["pdf","docx?","xlsx?","pp(t|s)x?","csv","rtf"];$("a").each(function(){if($(this).data("track"))return!1;var t=this,n=this.pathname||"";(n.match(new RegExp(".("+a.join("|")+")$","i"))||this.host!==window.location.host)&&$.each({event:"Link",action:"Clicked",label:n.replace(/(.*\/)+/,"")||this.innerHTML,value:window.location.pathname},function(a,n){$(t).attr("data-track","link").data(a,n)})}),$("a[href^=mailto]").each(function(){var t=$(this),a=t.attr("href");a=a.replace(/mailto:/,""),$.trim(a),t.data("event","Email Link"),t.data("action",a)}),$(t).on("click","a[data-track]",function(){var t=$(this);ga("send","event",t.data("event"),t.data("action"),t.data("value"),1)})}(document)},{}]},{},[1]);

--- a/themes/default/js/src/app.js
+++ b/themes/default/js/src/app.js
@@ -3,8 +3,9 @@
  * ---------------------------------------------------------------------------------
  */
 
-(function() {
-	"use strict";
+require('./ga.bigfork'); // run our GA code
 
-	
-})();
+/*
+var module = require('module'),
+	another = require('another');
+*/

--- a/themes/default/js/src/ga.bigfork.js
+++ b/themes/default/js/src/ga.bigfork.js
@@ -15,7 +15,7 @@
 
 		$.each({'event': 'Link', 'action': 'Clicked', 'label': (pathname.replace(/(.*\/)+/,'') || this.innerHTML), 'value': window.location.pathname}, function(attr, val) {
 			$(self).attr('data-track', 'link').data(attr, val);
-		}); 
+		});
 	});
 
 	$('a[href^=mailto]').each(function(){


### PR DESCRIPTION
add browserify to handle modules from npm, should we need them.

usage: `npm install <module> --save` then `var nice = require('<module>')` in app.js

_Note_: web modules get saved to `dependencies` in package.json, opposed to our gulp stuff which is in `devDependences`