### PR TITLE
Update autoprefix browser list

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -85,10 +85,11 @@ gulp.task('css', ['scss-lint'], function() {
 		}))
 		.pipe(sass())
 		.pipe(autoprefix({
-			browsers: ['last 2 versions', 'ie 8', 'ie 9', 'android 2.1']
+			browsers: ['ie >= 8', 'safari >= 8', '> 1%']
 		}))
 		.pipe(cmq())
 		.pipe(cssnano({
+			autoprefixer: false,
 			zindex: false
 		}))
 		.pipe(handle.generic.log('compiled'))


### PR DESCRIPTION
Whether `last 2 versions` refers to major or minor browser versions varies between browsers, so it’s pretty much useless. The `> 1%` will check the usage data on caniuse: http://caniuse.com/usage-table which is probably more relevant.

The prefixes were getting rekt by `cssnano()` anyway (e.g. it removes `display: -webkit-flex` and breaks flexbox in Safari 8) so I stopped it from touching them.